### PR TITLE
Fix #2: Make ProductDfa handle >2 underlying dfas

### DIFF
--- a/shield_synthesis/Dfa.h
+++ b/shield_synthesis/Dfa.h
@@ -124,7 +124,7 @@ public:
             edges_.clear();
         };
         
-        virtual bool operator==(Node& other) {
+        virtual bool operator ==(Node& other) {
             return id_ == other.id_;
         }
         

--- a/shield_synthesis/ProductDfa.h
+++ b/shield_synthesis/ProductDfa.h
@@ -4,6 +4,8 @@
 #include <exception>
 #include <vector>
 #include <list>
+#include <map>
+#include <unordered_set>
 
 class ProductDfa : public Dfa
 {
@@ -21,8 +23,6 @@ public:
         ProductDfaNode(ProductDfaNode* node) :
         Dfa::Node(-1)
         {
-            initial_ = node->initial_;
-            final_ = node->final_;
             
             for (auto subnode : node->subnodes_) {
                 subnodes_.push_back(subnode);
@@ -53,11 +53,16 @@ public:
                 }
                 return true;
             } catch (...) {
+                std::cout << "Error while comparing nodes!" << std::endl;
                 return false;
             }
         }
     };
+    public:
+        std::map<std::set<Node*>, ProductDfaNode*> subnode_node_map;
 
     ProductDfa(std::vector<Dfa*> args);
     std::vector<Dfa*> create_combinable_dfas(std::vector<Dfa*> originals);
+    std::vector<std::vector<Edge*>> create_cartesian(std::vector<std::vector<Edge*>>&);
+    std::vector<std::vector<Node*>> create_cartesian(std::vector<std::vector<Node*>>&);
 };

--- a/shield_synthesis/ShieldMonitor.cpp
+++ b/shield_synthesis/ShieldMonitor.cpp
@@ -20,7 +20,7 @@ Dfa(0, spec->num_inputs_ + spec->num_outputs_, spec->num_outputs_ + 1)
     
     names_[num_inputs_ + num_outputs_] = "recovery__s";
     
-    std::vector<Node*> good_nodes;
+    std::vector<Node*> good_nodes; // nodes to stay in e.g. non-final nodes
     for (auto node : spec->nodes_) {
         if (!node->final_) good_nodes.push_back(node);
     }


### PR DESCRIPTION
In the old implementation, ProductDfa broke for >2 underlying dfas.
The new implementation is set up using the following core steps:
* create a cartesian product of all dfa subnodes' combinations. Every
combination represents a product dfa node
* for every pdfa node, create a cartesian product for all outgoing edges
of its subnodes and like to the corresponding pdfa node. This represents
'following a combination of subnodes outgoing edges simultaneously'.

This implementation is aimed at correctness and can probably be
optimized.
The most obvious optimizations appear to be:
* only iterate over nodes that are connected to the initial node
* combine some for-loops iterating over all (pdfa) nodes
* possibly: early detection and reconciliation of final nodes

*NOTE*: I had to make some (local-specific?) changes to the repo to get my installation working. It's probably a good idea to test these changes on a fresh clone before merging. 